### PR TITLE
Continue on non package data instead of causing an exception

### DIFF
--- a/src/WGet.NET/Components/WinGetPackageManager.cs
+++ b/src/WGet.NET/Components/WinGetPackageManager.cs
@@ -19,6 +19,7 @@ namespace WGetNET
         private const string _installCmd = "install {0}";
         private const string _upgradeCmd = "upgrade {0}";
         private const string _getUpgradeableCmd = "upgrade";
+        private const string _includeUnknown = "--include-unknown";
         private const string _uninstallCmd = "uninstall {0}";
         private const string _exportCmd = "export -o {0}";
         private const string _importCmd = "import -i {0} --ignore-unavailable";
@@ -207,7 +208,7 @@ namespace WGetNET
         }
 
         /// <summary>
-        /// Uninsatll a package using winget.
+        /// Uninstall a package using winget.
         /// </summary>
         /// <param name="package">The <see cref="WGetNET.WinGetPackage"/> for the uninstallation.</param>
         /// <returns>
@@ -259,8 +260,20 @@ namespace WGetNET
         {
             try
             {
+                string argument = _getUpgradeableCmd;
+
+                // Checking version to determine if "--include-unknown" is necessary
+                int wingetVersion = 0;
+                bool castSuccessful = int.TryParse(WinGetVersion.Split("-")[0].Replace("v", "").Replace(".", ""), out wingetVersion);
+                
+                if (castSuccessful && wingetVersion >= 142161) 
+                {
+                    // Winget version supports new argument, add "--include-unknown" to arguments
+                    argument += " " + _includeUnknown;
+                }
+
                 ProcessResult result =
-                    _processManager.ExecuteWingetProcess(_getUpgradeableCmd);
+                    _processManager.ExecuteWingetProcess(argument);
 
                 return ProcessOutputReader.ToPackageList(result.Output);
             }

--- a/src/WGet.NET/HelperClasses/ProcessOutputReader.cs
+++ b/src/WGet.NET/HelperClasses/ProcessOutputReader.cs
@@ -71,7 +71,6 @@ namespace WGetNET.HelperClasses
             {
                 // [var1..var2] : selects the index range from var1 to var2
                 // (eg. if var1 is 2 and var2 is 5, the selectet index range will be [2, 3, 4])
-                if (output[i].Contains("upgrades available") || output[i].Contains("version numbers that")) { continue; }
                 try
                 {
                     resultList.Add(

--- a/src/WGet.NET/HelperClasses/ProcessOutputReader.cs
+++ b/src/WGet.NET/HelperClasses/ProcessOutputReader.cs
@@ -2,6 +2,7 @@
 // Created by basicx-StrgV                          //
 // https://github.com/basicx-StrgV/                 //
 //--------------------------------------------------//
+using System;
 using System.Collections.Generic;
 
 namespace WGetNET.HelperClasses
@@ -70,13 +71,18 @@ namespace WGetNET.HelperClasses
             {
                 // [var1..var2] : selects the index range from var1 to var2
                 // (eg. if var1 is 2 and var2 is 5, the selectet index range will be [2, 3, 4])
-                resultList.Add(
+                if (output[i].Contains("upgrades available") || output[i].Contains("version numbers that")) { continue; }
+                try
+                {
+                    resultList.Add(
                     new WinGetPackage()
                     {
                         PackageName = output[i][0..idStartIndex].Trim(),
                         PackageId = output[i][idStartIndex..versionStartIndex].Trim(),
                         PackageVersion = output[i][versionStartIndex..extraInfoStartIndex].Trim()
                     });
+                }
+                catch { continue; }
             }
 
             return resultList;

--- a/src/WGet.NET/XmlDocumentation/WGet.NET.xml
+++ b/src/WGet.NET/XmlDocumentation/WGet.NET.xml
@@ -144,7 +144,7 @@
         </member>
         <member name="M:WGetNET.WinGetPackageManager.UninstallPackage(WGetNET.WinGetPackage)">
             <summary>
-            Uninsatll a package using winget.
+            Uninstall a package using winget.
             </summary>
             <param name="package">The <see cref="T:WGetNET.WinGetPackage"/> for the uninstallation.</param>
             <returns>


### PR DESCRIPTION
It seems like the output from Winget has changed, thus causing an exception since two lines dont contain packages (Name, ID or version).
Simply ignoring these lines or putting the insides of the loop inside a try catch will prevent this.
There might be a better solution but for now, it works.