### PR TITLE
[docs] Add Sample for compare version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sourceManager.AddSource("msstore", "https://storeedgefd.dsx.mp.microsoft.com/v9.
 
 Using the ***WinGetPackageManager*** class you can use the `SearchPackage` capability to get the latest version of a package and then retrieve the version number from the `AvailableVersion` property.
 
-You would thn be able to compare this to the latest version of your executing assembly and determine if you need to notify users of an available upgrade.
+You would then be able to compare this to the latest version of your executing assembly and determine if you need to notify users of an available upgrade.
 
 ```csharp
 Version latestPackageVersion = null;

--- a/README.md
+++ b/README.md
@@ -98,3 +98,24 @@ The code for adding a source could look like this:
 WinGetSourceManager sourceManager = new WinGetSourceManager();
 sourceManager.AddSource("msstore", "https://storeedgefd.dsx.mp.microsoft.com/v9.0", "Microsoft.Rest");
 ```
+
+### Find Latest Versions of a Package:
+
+Using the ***WinGetPackageManager*** class you can use the `SearchPackage` capability to get the latest version of a package and then retrieve the version number from the `AvailableVersion` property.
+
+You would thn be able to compare this to the latest version of your executing assembly and determine if you need to notify users of an available upgrade.
+
+```csharp
+Version latestPackageVersion = null;
+WinGetPackageManager packageManager = new WinGetPackageManager();
+string packageId = "nkdAgility.AzureDevOpsMigrationTools";
+var package = packageManager.SearchPackage(PackageId).SingleOrDefault();
+latestPackageVersion = new Version(package.AvailableVersion);
+
+var version = Assembly.GetEntryAssembly().GetName().Version;
+if (latestPackageVersion > version)
+{
+    // Notify user of available upgrade
+    _logger.LogWarning("You are currently running version {version} and a newer version ({latestVersion}) is available. You should update now using Winget command 'winget {packageId}' from the Windows Terminal.", version, latestPackageVersion, packageId);
+}
+```


### PR DESCRIPTION
I added a sample to the readme.md to show how to notify users that there is an update to the winget package that contains the running application.

@basicx-StrgV I do not see how you build the docs, and since index.html looks like it has been generated, I did not add anything in there. Happy to do so if you can explain it? 

I added:
<hr />

### Find Latest Versions of a Package:

Using the ***WinGetPackageManager*** class you can use the `SearchPackage` capability to get the latest version of a package and then retrieve the version number from the `AvailableVersion` property.

You would thn be able to compare this to the latest version of your executing assembly and determine if you need to notify users of an available upgrade.

```csharp
Version latestPackageVersion = null;
WinGetPackageManager packageManager = new WinGetPackageManager();
string packageId = "nkdAgility.AzureDevOpsMigrationTools";
var package = packageManager.SearchPackage(PackageId).SingleOrDefault();
latestPackageVersion = new Version(package.AvailableVersion);

var version = Assembly.GetEntryAssembly().GetName().Version;
if (latestPackageVersion > version)
{
    // Notify user of available upgrade
    _logger.LogWarning("You are currently running version {version} and a newer version ({latestVersion}) is available. You should update now using Winget command 'winget {packageId}' from the Windows Terminal.", version, latestPackageVersion, packageId);
}
```
